### PR TITLE
feat: revamp landing page with schedule/workshop-focused content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,79 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# OHBM Hackathon Bordeaux 2026 Website
 
-## Getting Started
+Official landing page for OHBM Hackathon 2026 (June 11-13, Bordeaux, France).
 
-First, run the development server:
+## Overview
+
+This site includes:
+
+- Hero section with animated neural-network visual
+- Event info and venue highlight
+- 3-day interactive schedule (tabbed timeline)
+- Sponsor section + contact CTA
+- Footer links and event metadata
+
+The page is built as a static-exported Next.js app and deployed to GitHub Pages.
+
+## Tech Stack
+
+- Next.js `16.1.3` (App Router)
+- React `19.2.3`
+- TypeScript `5`
+- Tailwind CSS `4`
+- Radix UI + shadcn/ui
+- Lucide React icons
+- Vercel Analytics (`@vercel/analytics`)
+
+## Local Development
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open `http://localhost:3000`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Scripts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- `npm run dev`: start dev server
+- `npm run build`: production build + static export (`out/`)
+- `npm run start`: run production server
+- `npm run lint`: run ESLint
 
-## Learn More
+## Project Structure
 
-To learn more about Next.js, take a look at the following resources:
+- `src/app/layout.tsx`: metadata, fonts, global layout
+- `src/app/page.tsx`: section composition order
+- `src/app/globals.css`: theme tokens and base styling
+- `src/components/hero-section.tsx`: hero + brain animation
+- `src/components/info-section.tsx`: event highlights + venue visual
+- `src/components/schedule-section.tsx`: schedule UI and schedule data
+- `src/components/sponsors-section.tsx`: sponsor/CTA content
+- `src/components/scroll-fade.tsx`: section entrance/exit scroll transitions
+- `schedule.md`: planning/reference schedule document (not auto-wired to UI)
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Content Update Guide
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+1. Event title/description (SEO): update `src/app/layout.tsx`.
+2. Hero copy/date/location: update `src/components/hero-section.tsx`.
+3. Schedule data and track tags: update `src/components/schedule-section.tsx`.
+4. Sponsor entries and logo paths: update `src/components/sponsors-section.tsx` and add assets to `public/`.
+5. Footer links/text: update `src/components/footer.tsx`.
 
-## Deploy on Vercel
+Note: `schedule.md` is documentation for planning. The live schedule currently comes from the `schedule` object in `schedule-section.tsx`.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Deployment (GitHub Pages)
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Deployment runs via `.github/workflows/nextjs.yml` on pushes to `main`.
+
+Static hosting settings are in `next.config.ts`:
+
+- `output: "export"`
+- `images.unoptimized: true`
+- `basePath` / `assetPrefix` for repository subpath deployment
+
+If the repository name changes, update `repositoryName` in `next.config.ts`.
+
+## License
+
+MIT

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} antialiased`}>
+      <body className={`${inter.className} antialiased snap-y snap-proximity scroll-smooth`}>
         {children}
         <Analytics />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,32 @@
 import { HeroSection } from "@/components/hero-section";
 import { InfoSection } from "@/components/info-section";
+import { ScheduleSection } from "@/components/schedule-section";
+import { WorkshopsSection } from "@/components/workshops-section";
 import { SponsorsSection } from "@/components/sponsors-section";
 import { Footer } from "@/components/footer";
+import { ScrollFade } from "@/components/scroll-fade";
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-background text-foreground">
-      <HeroSection />
-      <InfoSection />
-      <SponsorsSection />
-      <Footer />
+    <main className="bg-background text-foreground overflow-x-hidden snap-y snap-proximity">
+      <ScrollFade className="snap-start" enterScale={0.98} exitScale={1.03} travelY={16} blurPx={6}>
+        <HeroSection />
+      </ScrollFade>
+      <ScrollFade className="snap-start">
+        <InfoSection />
+      </ScrollFade>
+      <ScrollFade className="snap-start">
+        <ScheduleSection />
+      </ScrollFade>
+      <ScrollFade className="snap-start">
+        <WorkshopsSection />
+      </ScrollFade>
+      <ScrollFade className="snap-start" disableExit>
+        <>
+          <SponsorsSection />
+          <Footer />
+        </>
+      </ScrollFade>
     </main>
   );
 }

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -364,18 +364,12 @@ export function HeroSection() {
           >
             Schedule
           </a>
-          <a
-            href="#hack-track"
-            className="hover:text-foreground transition-colors"
-          >
+          <span className="text-muted-foreground/50 cursor-default select-none">
             Hack Track
-          </a>
-          <a
-            href="#train-track"
-            className="hover:text-foreground transition-colors"
-          >
+          </span>
+          <span className="text-muted-foreground/50 cursor-default select-none">
             Train Track
-          </a>
+          </span>
           <a
             href="#workshop"
             className="hover:text-foreground transition-colors"
@@ -425,10 +419,19 @@ export function HeroSection() {
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <span className="text-muted-foreground text-sm">More details</span>
-            <span className="px-3 py-1 rounded-full bg-accent/20 text-accent text-xs font-medium">
-              TBA
-            </span>
+            <span className="text-muted-foreground text-sm">Latest info</span>
+            <a
+              href="#schedule"
+              className="px-3 py-1 rounded-full bg-accent/20 text-accent text-xs font-medium hover:opacity-80 transition-opacity"
+            >
+              Official schedule published
+            </a>
+            <a
+              href="#workshop"
+              className="px-3 py-1 rounded-full border border-border text-xs font-medium hover:bg-muted transition-colors"
+            >
+              Workshop guide available
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/info-section.tsx
+++ b/src/components/info-section.tsx
@@ -1,4 +1,4 @@
-import { Code, Users, Trophy, Lightbulb } from "lucide-react";
+import { Code, Lightbulb, MapPin, TramFront, Trophy, Users } from "lucide-react";
 import Image from "next/image";
 
 const basePath = process.env.NODE_ENV === "production" ? "/hackathon2026" : "";
@@ -44,29 +44,78 @@ export function InfoSection() {
         ))}
       </div>
 
-      {/* Location Preview */}
       <div className="border-t border-border p-8 md:p-12">
-        <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-3xl md:text-4xl font-bold mb-4 text-balance">
-            Experience the heart of French wine country
-          </h2>
-          <p className="text-muted-foreground text-lg leading-relaxed mb-8 max-w-2xl mx-auto">
-            Bordeaux combines world-class culture, stunning architecture, and a
-            thriving tech scene. The perfect backdrop for your next breakthrough
-            idea.
-          </p>
-          <div className="relative aspect-[21/9] rounded-xl overflow-hidden border border-border">
-            <Image
-              src={`${basePath}/bordeaux.jpeg`}
-              alt="Bordeaux cityscape"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-background/80 to-transparent" />
-            <div className="absolute bottom-6 left-6 text-left">
-              <p className="text-sm text-muted-foreground">Venue location</p>
-              <p className="text-xl font-semibold">
-                Campus Victoire, University of Bordeaux
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-8">
+            <h2 className="text-3xl md:text-4xl font-bold mb-4 text-balance">
+              Plan Your Stay Around The Venue
+            </h2>
+            <p className="text-muted-foreground text-lg leading-relaxed max-w-3xl mx-auto">
+              The hackathon runs from Thursday, June 11 to Saturday, June 13 at Campus Victoire,
+              University of Bordeaux. Use the city photo and satellite map below to choose nearby
+              travel and lodging.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="relative aspect-[4/3] rounded-xl overflow-hidden border border-border">
+              <Image
+                src={`${basePath}/bordeaux.jpeg`}
+                alt="Bordeaux cityscape near the event venue"
+                fill
+                className="object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-background/80 to-transparent" />
+              <div className="absolute bottom-6 left-6 text-left">
+                <p className="text-sm text-muted-foreground">Location photo</p>
+                <p className="text-xl font-semibold">Campus Victoire Area</p>
+              </div>
+            </div>
+
+            <div className="relative aspect-[4/3] rounded-xl overflow-hidden border border-border bg-card">
+              <iframe
+                title="Satellite map around Campus Victoire, Bordeaux"
+                src="https://www.google.com/maps?q=Campus+Victoire+University+of+Bordeaux&hl=en&t=k&z=15&output=embed"
+                className="absolute inset-0 h-full w-full"
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+              />
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/90 to-transparent p-6 text-left">
+                <p className="text-sm text-muted-foreground">Satellite view</p>
+                <p className="text-xl font-semibold">Transit And Lodging Context</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="flex items-center gap-2 mb-2 text-sm font-semibold">
+                <MapPin className="w-4 h-4 text-muted-foreground" />
+                Venue
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Campus Victoire, University of Bordeaux. We recommend staying in central Bordeaux
+                with reliable tram access.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="flex items-center gap-2 mb-2 text-sm font-semibold">
+                <TramFront className="w-4 h-4 text-muted-foreground" />
+                Daily Timing
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Doors open as early as 07:30 on all three days. Plan your morning commute before
+                the first sessions.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="flex items-center gap-2 mb-2 text-sm font-semibold">
+                <Users className="w-4 h-4 text-muted-foreground" />
+                Lodging Tip
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Book through Saturday night if you want to join late sessions and closing updates
+                comfortably.
               </p>
             </div>
           </div>

--- a/src/components/schedule-section.tsx
+++ b/src/components/schedule-section.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { CalendarDays, Clock } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+type ScheduleTrack = "General" | "Hack Track" | "Train Track" | "Workshop";
+
+type ScheduleItem = {
+  event: string;
+  track: ScheduleTrack;
+  location: string;
+};
+
+type ScheduleBlock =
+  | {
+      time: string;
+      columns: 1;
+      item: ScheduleItem;
+    }
+  | {
+      time: string;
+      columns: 2;
+      left: ScheduleItem;
+      right: ScheduleItem;
+    };
+
+type TimeRange = {
+  start: number;
+  end: number;
+};
+
+const SLOT_MINUTES = 30;
+const SLOT_HEIGHT_PX = 42;
+const TIMELINE_BOTTOM_PADDING_PX = 18;
+
+const parseClock = (value: string) => {
+  const [hour, minute] = value.trim().split(":").map(Number);
+  return hour * 60 + minute;
+};
+
+const parseTimeRange = (value: string): TimeRange => {
+  const [startRaw, endRaw] = value.split("-").map((part) => part.trim());
+  return {
+    start: parseClock(startRaw),
+    end: parseClock(endRaw),
+  };
+};
+
+const formatClock = (minuteOfDay: number) => {
+  const hour = Math.floor(minuteOfDay / 60)
+    .toString()
+    .padStart(2, "0");
+  const minute = (minuteOfDay % 60).toString().padStart(2, "0");
+  return `${hour}:${minute}`;
+};
+
+const toPixels = (minutes: number) => (minutes / SLOT_MINUTES) * SLOT_HEIGHT_PX;
+
+const schedule = {
+  day1: [
+    {
+      time: "07:30 - 09:00",
+      columns: 1,
+      item: { event: "Soft Launch", track: "General", location: "Venue Open" },
+    },
+    {
+      time: "09:00 - 09:30",
+      columns: 1,
+      item: { event: "Registration & Soft Opening", track: "General", location: "Main Hall" },
+    },
+    {
+      time: "09:30 - 12:00",
+      columns: 2,
+      left: { event: "Brainstorming + Last Project Submissions", track: "Hack Track", location: "Hack Room" },
+      right: { event: "Introductions: Brainhacking (10+5 min talks)", track: "Train Track", location: "Train Room" },
+    },
+    {
+      time: "12:00 - 13:00",
+      columns: 1,
+      item: { event: "Lunch", track: "General", location: "Cafeteria" },
+    },
+    {
+      time: "13:00 - 14:30",
+      columns: 1,
+      item: { event: "Project Pitches", track: "General", location: "Main Stage" },
+    },
+    {
+      time: "14:30 - 16:00",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "Working On Projects", track: "Train Track", location: "Train Room" },
+    },
+    {
+      time: "16:00 - 16:30",
+      columns: 1,
+      item: { event: "Coffee Break", track: "General", location: "Common Area" },
+    },
+    {
+      time: "16:30 - 17:30",
+      columns: 1,
+      item: { event: "Un-conference", track: "General", location: "Main Stage" },
+    },
+    {
+      time: "17:30 - 19:00",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "People's Choice Session", track: "Train Track", location: "Train Room" },
+    },
+    {
+      time: "19:00 - 19:30",
+      columns: 1,
+      item: { event: "Building Almost Closes", track: "General", location: "Venue" },
+    },
+    {
+      time: "19:30 - 20:00",
+      columns: 1,
+      item: { event: "Building Closes", track: "General", location: "Venue" },
+    },
+  ],
+  day2: [
+    {
+      time: "07:30 - 09:00",
+      columns: 1,
+      item: { event: "Soft Launch", track: "General", location: "Venue Open" },
+    },
+    {
+      time: "09:00 - 12:00",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "Deeper Traintracks: Topic Deep Dives", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "12:00 - 13:30",
+      columns: 1,
+      item: { event: "Lunch", track: "General", location: "Cafeteria" },
+    },
+    {
+      time: "13:30 - 14:30",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "BIDS / hMRI / EEG101 / Stats", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "14:30 - 15:30",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "BIDS / hMRI / EEG101 / Stats", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "15:30 - 16:00",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "BIDS / hMRI / EEG101 / Stats", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "16:00 - 16:30",
+      columns: 1,
+      item: { event: "Coffee Break", track: "General", location: "Common Area" },
+    },
+    {
+      time: "16:30 - 17:30",
+      columns: 1,
+      item: { event: "Un-conference", track: "General", location: "Main Stage" },
+    },
+    {
+      time: "17:30 - 19:00",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "BIDS / hMRI / EEG101 / Stats", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "19:00 - 19:30",
+      columns: 1,
+      item: { event: "Building Almost Closes", track: "General", location: "Venue" },
+    },
+    {
+      time: "19:30 - 20:00",
+      columns: 1,
+      item: { event: "Building Closes", track: "General", location: "Venue" },
+    },
+  ],
+  day3: [
+    {
+      time: "07:30 - 09:00",
+      columns: 1,
+      item: { event: "Soft Launch", track: "General", location: "Venue Open" },
+    },
+    {
+      time: "09:00 - 12:00",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "EEG101 + Stats", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "12:00 - 13:30",
+      columns: 1,
+      item: { event: "Lunch", track: "General", location: "Cafeteria" },
+    },
+    {
+      time: "13:30 - 14:00",
+      columns: 1,
+      item: { event: "Un-conference", track: "General", location: "Main Stage" },
+    },
+    {
+      time: "14:00 - 16:00",
+      columns: 2,
+      left: { event: "Working On Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "Working On Projects", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "16:00 - 16:30",
+      columns: 1,
+      item: { event: "Coffee Break", track: "General", location: "Common Area" },
+    },
+    {
+      time: "16:30 - 17:30",
+      columns: 2,
+      left: { event: "Wrapping Up Projects", track: "Hack Track", location: "Hack Room" },
+      right: { event: "Wrapping Up Projects", track: "Workshop", location: "Workshop Room" },
+    },
+    {
+      time: "17:30 - 19:00",
+      columns: 1,
+      item: { event: "Closing Ceremony + Project Updates", track: "General", location: "Main Stage" },
+    },
+    {
+      time: "19:00 - 19:30",
+      columns: 1,
+      item: { event: "Building Almost Closes", track: "General", location: "Venue" },
+    },
+    {
+      time: "19:30 - 20:00",
+      columns: 1,
+      item: { event: "Building Closes", track: "General", location: "Venue" },
+    },
+  ],
+} satisfies Record<string, ScheduleBlock[]>;
+
+const getTrackBadgeClass = (track: ScheduleTrack) => {
+  if (track === "Hack Track") return "bg-blue-500/10 text-blue-500";
+  if (track === "Train Track") return "bg-emerald-500/10 text-emerald-600";
+  if (track === "Workshop") return "bg-amber-500/10 text-amber-600";
+  return "bg-muted text-muted-foreground";
+};
+
+const getTrackCardClass = (track: ScheduleTrack) => {
+  if (track === "Hack Track") return "bg-blue-500/5 border-blue-500/40";
+  if (track === "Train Track") return "bg-emerald-500/5 border-emerald-500/40";
+  if (track === "Workshop") return "bg-amber-500/5 border-amber-500/40";
+  return "bg-card border-border";
+};
+
+function TimelineEvent({ item, compact = false }: { item: ScheduleItem; compact?: boolean }) {
+  return (
+    <div
+      className={`h-full rounded-md border overflow-hidden ${compact ? "p-2" : "p-3"} ${getTrackCardClass(item.track)}`}
+    >
+      <div className={`flex items-center gap-2 ${compact ? "" : "mb-2"}`}>
+        <span
+          className={`shrink-0 px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider ${getTrackBadgeClass(item.track)}`}
+        >
+          {item.track}
+        </span>
+        {compact ? (
+          <h4 className="min-w-0 truncate text-xs font-semibold leading-tight">{item.event}</h4>
+        ) : null}
+      </div>
+
+      {!compact ? <h4 className="font-semibold text-sm leading-tight">{item.event}</h4> : null}
+    </div>
+  );
+}
+
+export function ScheduleSection() {
+  return (
+    <section id="schedule" className="py-24 px-6 border-t border-border bg-background">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl md:text-5xl font-bold tracking-tight">Schedule</h2>
+        </div>
+
+        <div className="mb-10 rounded-2xl border border-border bg-card p-6">
+          <div className="flex items-center gap-2 text-sm font-semibold mb-2">
+            <CalendarDays className="w-4 h-4 text-muted-foreground" />
+            Schedule status
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Version v1.0 published. Daily activities begin at 07:30 and the building closes at
+            20:00.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
+          <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/5 p-5">
+            <h3 className="font-semibold text-base mb-1">Train Track / Workshop</h3>
+            <p className="text-sm text-muted-foreground">
+              Train Track starts with onboarding and deeper topic sessions for practical project
+              participation. Workshop-specific details are provided later in the Workshop Guide.
+            </p>
+          </div>
+          <div className="rounded-xl border border-blue-500/40 bg-blue-500/5 p-5">
+            <h3 className="font-semibold text-base mb-1">Hack Track</h3>
+            <p className="text-sm text-muted-foreground">
+              Project-first track with extended build blocks, unconference slots, and final closing
+              updates.
+            </p>
+          </div>
+        </div>
+
+        <Tabs defaultValue="day1" className="w-full">
+          <TabsList className="grid w-full grid-cols-3 mb-4">
+            <TabsTrigger value="day1" className="py-3">
+              Day 1 (June 11)
+            </TabsTrigger>
+            <TabsTrigger value="day2" className="py-3">
+              Day 2 (June 12)
+            </TabsTrigger>
+            <TabsTrigger value="day3" className="py-3">
+              Day 3 (June 13)
+            </TabsTrigger>
+          </TabsList>
+
+          {Object.entries(schedule).map(([day, events]) => (
+            <TabsContent key={day} value={day}>
+              {(() => {
+                const parsed = events.map((block, index) => ({
+                  block,
+                  index,
+                  range: parseTimeRange(block.time),
+                }));
+
+                const dayStart = Math.min(...parsed.map(({ range }) => range.start));
+                const dayEnd = Math.max(...parsed.map(({ range }) => range.end));
+                const totalHeight = toPixels(dayEnd - dayStart);
+                const timelineHeight = totalHeight + TIMELINE_BOTTOM_PADDING_PX;
+
+                const markers: number[] = [];
+                for (let minute = dayStart; minute <= dayEnd; minute += SLOT_MINUTES) {
+                  markers.push(minute);
+                }
+
+                return (
+                  <div className="rounded-xl border border-border bg-card overflow-hidden">
+                    <div className="grid grid-cols-[82px_minmax(0,1fr)] border-b border-border bg-muted/30">
+                      <div className="px-3 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                        Time
+                      </div>
+                      <div className="px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                        Sessions
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-[82px_minmax(0,1fr)]">
+                      <div className="relative border-r border-border bg-muted/20" style={{ height: timelineHeight }}>
+                        {markers.map((minute) => {
+                          const top = toPixels(minute - dayStart);
+                          return (
+                            <div
+                              key={minute}
+                              className="absolute left-0 right-0 -translate-y-1/2 px-3 text-[11px] text-muted-foreground"
+                              style={{ top }}
+                            >
+                              <div className="flex items-center gap-2">
+                                <Clock className="w-3 h-3" />
+                                <span>{formatClock(minute)}</span>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+
+                      <div className="relative overflow-hidden" style={{ height: timelineHeight }}>
+                        {markers.map((minute) => {
+                          const top = toPixels(minute - dayStart);
+                          const hourLine = minute % 60 === 0;
+                          return (
+                            <div
+                              key={minute}
+                              className={`absolute left-0 right-0 border-t ${hourLine ? "border-border" : "border-border/40"}`}
+                              style={{ top }}
+                            />
+                          );
+                        })}
+
+                        <div className="absolute top-0 bottom-0 left-1/2 w-px bg-border/60" />
+
+                        {parsed.map(({ block, index, range }) => {
+                          const top = toPixels(range.start - dayStart);
+                          const height = Math.max(toPixels(range.end - range.start), SLOT_HEIGHT_PX * 0.9);
+
+                          const durationMinutes = range.end - range.start;
+                          const compact = durationMinutes <= SLOT_MINUTES;
+
+                          if (block.columns === 1) {
+                            return (
+                              <div key={index} className="absolute px-2" style={{ top, height, left: 0, right: 0 }}>
+                                <TimelineEvent item={block.item} compact={compact} />
+                              </div>
+                            );
+                          }
+
+                          return (
+                            <div key={index} className="contents">
+                              <div
+                                className="absolute pl-2 pr-1"
+                                style={{
+                                  top,
+                                  height,
+                                  left: 0,
+                                  width: "50%",
+                                }}
+                              >
+                                <TimelineEvent item={block.left} compact={compact} />
+                              </div>
+                              <div
+                                key={`${index}-right`}
+                                className="absolute pl-1 pr-2"
+                                style={{
+                                  top,
+                                  height,
+                                  left: "50%",
+                                  width: "50%",
+                                }}
+                              >
+                                <TimelineEvent item={block.right} compact={compact} />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })()}
+            </TabsContent>
+          ))}
+        </Tabs>
+
+        <div className="mt-16 p-8 rounded-2xl bg-muted/50 border border-border flex flex-col md:flex-row items-center justify-between gap-6">
+          <div className="max-w-2xl">
+            <h4 className="text-xl font-semibold mb-1">Detailed Program (PDF)</h4>
+            <p className="text-muted-foreground">
+              More detailed session information will be provided in the official PDF booklet. Please
+              refer to the PDF for finalized room assignments, workshop notes, and practical details.
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              disabled
+              aria-disabled="true"
+              className="px-6 py-2 rounded-lg bg-primary/50 text-primary-foreground/80 font-medium cursor-not-allowed"
+            >
+              Download PDF (Placeholder)
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/scroll-fade.tsx
+++ b/src/components/scroll-fade.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type ScrollFadeProps = {
+  children: ReactNode;
+  className?: string;
+  enterScale?: number;
+  exitScale?: number;
+  blurPx?: number;
+  travelY?: number;
+  disableExit?: boolean;
+};
+
+type TransitionStyle = {
+  opacity: number;
+  transform: string;
+  filter: string;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+const lerp = (start: number, end: number, t: number) => start + (end - start) * t;
+
+export function ScrollFade({
+  children,
+  className,
+  enterScale = 0.96,
+  exitScale = 1.04,
+  blurPx = 9,
+  travelY = 34,
+  disableExit = false,
+}: ScrollFadeProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [styleState, setStyleState] = useState<TransitionStyle>({
+    opacity: 0,
+    transform: `translate3d(0, ${travelY}px, 0) scale(${enterScale})`,
+    filter: "blur(0px)",
+  });
+
+  useEffect(() => {
+    const target = ref.current;
+    if (!target) return;
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReducedMotion) {
+      const reducedMotionFrame = window.requestAnimationFrame(() => {
+        setStyleState({
+          opacity: 1,
+          transform: "translate3d(0, 0, 0) scale(1)",
+          filter: "blur(0px)",
+        });
+      });
+      return () => window.cancelAnimationFrame(reducedMotionFrame);
+    }
+
+    let frameId = 0;
+
+    const update = () => {
+      const rect = target.getBoundingClientRect();
+      const vh = window.innerHeight || 1;
+
+      let opacity = 1;
+      let scale = 1;
+      let translateY = 0;
+      let blur = 0;
+
+      const enterStartTop = vh * 0.95; // section starts appearing from bottom
+      const enterEndTop = vh * 0.68; // fully visible around this point
+      const enterUpper = Math.max(enterStartTop, enterEndTop);
+      const enterLower = Math.min(enterStartTop, enterEndTop);
+
+      // Start dissolving when the next section occupies about half of the viewport.
+      const exitStartBottom = vh * 0.5;
+      const exitEndBottom = -vh * 0.15; // fully gone just after crossing top
+      const exitUpper = Math.max(exitStartBottom, exitEndBottom);
+      const exitLower = Math.min(exitStartBottom, exitEndBottom);
+
+      if (rect.top >= enterUpper) {
+        opacity = 0;
+        scale = enterScale;
+        translateY = travelY;
+      } else if (rect.top > enterLower) {
+        const t = clamp((enterUpper - rect.top) / (enterUpper - enterLower), 0, 1);
+        opacity = lerp(0, 1, t);
+        scale = lerp(enterScale, 1, t);
+        translateY = lerp(travelY, 0, t);
+      } else if (disableExit || rect.bottom > exitUpper) {
+        // Hold zone: keep the current section crisp and stable.
+        opacity = 1;
+        scale = 1;
+        translateY = 0;
+        blur = 0;
+      } else if (rect.bottom > exitLower) {
+        const t = clamp((exitUpper - rect.bottom) / (exitUpper - exitLower), 0, 1);
+        opacity = lerp(1, 0, t);
+        scale = lerp(1, exitScale, t);
+        translateY = lerp(0, -Math.round(travelY * 0.32), t);
+        blur = lerp(0, blurPx, t);
+      } else {
+        opacity = 0;
+        scale = exitScale;
+        translateY = -Math.round(travelY * 0.32);
+        blur = blurPx;
+      }
+
+      setStyleState({
+        opacity,
+        transform: `translate3d(0, ${translateY}px, 0) scale(${scale})`,
+        filter: `blur(${blur}px)`,
+      });
+    };
+
+    const schedule = () => {
+      if (frameId) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = 0;
+        update();
+      });
+    };
+
+    update();
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule);
+    return () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+    };
+  }, [blurPx, disableExit, enterScale, exitScale, travelY]);
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "will-change-transform motion-reduce:opacity-100 motion-reduce:transform-none",
+        className,
+      )}
+      style={{
+        opacity: styleState.opacity,
+        transform: styleState.transform,
+        filter: styleState.filter,
+        transitionProperty: "opacity, transform, filter",
+        transitionDuration: "220ms, 260ms, 260ms",
+        transitionTimingFunction: "linear, cubic-bezier(0.22, 1, 0.36, 1), cubic-bezier(0.22, 1, 0.36, 1)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/workshops-section.tsx
+++ b/src/components/workshops-section.tsx
@@ -1,0 +1,65 @@
+import { BookOpen, Brain, Microscope, NotebookPen } from "lucide-react";
+
+type WorkshopItem = {
+  title: string;
+  format: string;
+  description: string;
+  icon: typeof BookOpen;
+};
+
+const workshops: WorkshopItem[] = [
+  {
+    title: "Neuroimaging Statistics Workshop",
+    format: "2x half-day",
+    description:
+      "The Neuroimaging Statistics Workshop will showcase emerging methods in brain image modeling and analysis. It combines lectures by leaders in neuroimaging statistics with opportunities to network among students and researchers.",
+    icon: NotebookPen,
+  },
+  {
+    title: "EEG101 Workshop",
+    format: "2x half-day",
+    description:
+      "EEG101 aims to bring together the EEG community to develop and collaborate on standardized tools and protocols for analysis and reporting, curate and harmonise large datasets, and establish centralized platforms for resource sharing and collaboration.",
+    icon: Brain,
+  },
+  {
+    title: "BIDS Workshop",
+    format: "half-day",
+    description:
+      "The BIDS workshop will educate and discuss standards for prescribing a formal way to organize various imaging data types and metadata. It simplifies communication and collaboration between users and enables easier data validation and software development.",
+    icon: BookOpen,
+  },
+  {
+    title: "hMRI Workshop",
+    format: "half-day",
+    description:
+      "The hMRI workshop will introduce quantitative MRI methods and their analysis via the hMRI-toolbox embedded in SPM. It allows the estimation of high-quality multi-parameter qMRI maps (R1, R2*, PD and MT) followed by spatial registration for statistical analysis.",
+    icon: Microscope,
+  },
+];
+
+export function WorkshopsSection() {
+  return (
+    <section id="workshop" className="py-24 px-6 border-t border-border bg-muted/20">
+      <div className="max-w-5xl mx-auto">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl md:text-5xl font-bold tracking-tight">Workshops</h2>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {workshops.map((workshop) => (
+            <article key={workshop.title} className="rounded-xl border border-border bg-card p-6">
+              <div className="flex items-center gap-2 mb-3 text-sm font-semibold">
+                <workshop.icon className="w-4 h-4 text-muted-foreground" />
+                Workshop
+              </div>
+              <h3 className="text-xl font-semibold mb-2">{workshop.title}</h3>
+              <p className="text-sm text-muted-foreground mb-3">Format: {workshop.format}</p>
+              <p className="text-sm leading-relaxed text-muted-foreground">{workshop.description}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
- add new `ScheduleSection` with 3-day tabbed timetable and compact 30-min event rendering
- add new `WorkshopsSection` with updated workshop descriptions and format labels
- integrate section-based scroll transitions via new `ScrollFade` component
- update hero nav/status chips and remove ambiguous track anchors/TBA messaging
- expand info section with venue-focused visual content (photo + satellite context)
- enable smooth snap scrolling in root layout
- rewrite README with current stack, structure, content update guide, and GitHub Pages deployment notes