### PR TITLE
Clarify Brainhack registration and submission paths

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { MapPin, Calendar, Clock } from "lucide-react";
+import { MapPin, Calendar, Clock, ExternalLink } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState, useRef } from "react";
 
 const basePath = process.env.NODE_ENV === "production" ? "/hackathon2026" : "";
+const registrationUrl = "https://humanbrainmapping.org/26Brainhack";
 
 interface NeuralNetworkProps {
   className?: string;
@@ -377,6 +378,15 @@ export function HeroSection() {
           >
             Workshop
           </a>
+          <a
+            href={registrationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-primary-foreground font-medium transition-opacity hover:opacity-85"
+          >
+            Register
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
         </div>
       </nav>
 
@@ -419,8 +429,17 @@ export function HeroSection() {
               <span>3 Days</span>
             </div>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-center gap-3">
             <span className="text-muted-foreground text-sm">Latest info</span>
+            <a
+              href={registrationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-85"
+            >
+              Brainhack Registration
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
             <a
               href="#hacktrack"
               className="px-3 py-1 rounded-full bg-accent/20 text-accent text-xs font-medium hover:opacity-80 transition-opacity"

--- a/src/components/schedule-section.tsx
+++ b/src/components/schedule-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CalendarDays, Clock } from "lucide-react";
+import { CalendarDays, Clock, ExternalLink } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 type ScheduleTrack = "General" | "Hack Track" | "Train Track" | "Workshop" | "Break" | "Un-Conference";
@@ -36,6 +36,7 @@ type TimeRange = {
 const SLOT_MINUTES = 30;
 const SLOT_HEIGHT_PX = 42;
 const TIMELINE_BOTTOM_PADDING_PX = 18;
+const registrationUrl = "https://humanbrainmapping.org/26Brainhack";
 
 const parseClock = (value: string) => {
   const [hour, minute] = value.trim().split(":").map(Number);
@@ -316,14 +317,27 @@ export function ScheduleSection() {
         </div>
 
         <div className="mb-10 rounded-2xl border border-border bg-card p-6">
-          <div className="flex items-center gap-2 text-sm font-semibold mb-2">
-            <CalendarDays className="w-4 h-4 text-muted-foreground" />
-            Schedule status
+          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div className="flex items-center gap-2 text-sm font-semibold mb-2">
+                <CalendarDays className="w-4 h-4 text-muted-foreground" />
+                Schedule status
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Version v1.0 published. Daily activities begin at 07:30 and the building closes at
+                20:00.
+              </p>
+            </div>
+            <a
+              href={registrationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium transition-colors hover:bg-background"
+            >
+              Register for OHBM Brainhack
+              <ExternalLink className="h-4 w-4" />
+            </a>
           </div>
-          <p className="text-sm text-muted-foreground">
-            Version v1.0 published. Daily activities begin at 07:30 and the building closes at
-            20:00.
-          </p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">

--- a/src/components/track-browser.tsx
+++ b/src/components/track-browser.tsx
@@ -413,7 +413,7 @@ export function TrackBrowser({
                 rel="noreferrer"
                 className="inline-flex items-center gap-2 rounded-full bg-foreground px-5 py-3 text-sm font-medium text-background transition-opacity hover:opacity-85"
               >
-                Register via GitHub Issue
+                Submit via GitHub Issue
                 <ArrowUpRight className="h-4 w-4" />
               </a>
               <a
@@ -479,7 +479,7 @@ export function TrackBrowser({
 
           <div className="mb-6">
             <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
-              {kind === "hacktrack" ? "Current registered projects" : "Current registered tutorials"}
+              {kind === "hacktrack" ? "Current submitted projects" : "Current submitted tutorials"}
             </p>
           </div>
 
@@ -487,7 +487,7 @@ export function TrackBrowser({
             <div className="rounded-3xl border border-dashed border-border bg-card/60 px-6 py-14 text-center">
               <p className="text-lg font-medium">No entries match the current filter.</p>
               <p className="mt-2 text-sm text-muted-foreground">
-                Try another search term, clear the active tag, or use the register button above to add a new entry.
+                Try another search term, clear the active tag, or use the submit button above to add a new entry.
               </p>
             </div>
           ) : (


### PR DESCRIPTION
The Brainhack page now separates attendee registration from GitHub issue submissions so visitors can find the official registration link without confusing it with HackTrack or TrainTrack proposal intake.

Constraint: Registration must point to the OHBM 26Brainhack page while track intake remains GitHub issue based
Rejected: Leave TrackBrowser CTA as registration | conflates attendee signup with project/tutorial submission
Confidence: high
Scope-risk: narrow
Directive: Keep attendee registration CTAs distinct from GitHub issue submission CTAs
Tested: npm run lint
Related: #9
Related: #19