### PR TITLE
Update INDoS/EEG101 workshop site link

### DIFF
--- a/src/components/workshops-section.tsx
+++ b/src/components/workshops-section.tsx
@@ -26,7 +26,7 @@ const workshops: WorkshopItem[] = [
     description:
       "The INDoS and EEG101 EU COST actions are bringing together the EEG and wider neuroimaging community to develop and collaborate on standardized tools and protocols for analysis and reporting, curate and harmonise large datasets to establish centralized platforms for resource sharing and collaboration. ",
     icon: Brain,
-    links: [{ label: "RS-BIDSify repo", href: "https://github.com/ubdbra001/rs-bidsify"}]
+    links: [{ label: "Workshop Site", href: "https://ancplaboldenburg.github.io/indos-eeg101-workshops-brainhack/"}]
   },
   {
     title: "BIDS Workshop",


### PR DESCRIPTION
## Description
This PR updates the INDoS/EEG101 workshop entry to point users to the correct workshop website instead of the old repository link.

## Changes
- Renamed the link label from RS-BIDSify repo to Workshop Site
- Updated the URL to https://ancplaboldenburg.github.io/indos-eeg101-workshops-brainhack/

## Related Issue
Fixes #10

## Testing
- Not run; content-only link update.